### PR TITLE
Better search filtering and more parameters for sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "This project was bootstrapped with Fastify-CLI.",
   "main": "app.js",
   "directories": {
@@ -13,7 +13,7 @@
     "dev": "fastify start -w -l info -P app.js"
   },
   "keywords": [],
-  "author": "",
+  "author": "LegitiDevs",
   "license": "ISC",
   "dependencies": {
     "@fastify/autoload": "^6.0.0",

--- a/routes/all/index.js
+++ b/routes/all/index.js
@@ -11,8 +11,10 @@ const worlds = mongoclient.db(DB).collection("worlds");
 
 export default async function (fastify, opts) {
   fastify.get("/", async function (request, reply) {
-    console.log(request.query.sort, getSortingMethod(request.query.sort))
-    const sortingMethod = getSortingMethod(request.query.sort)
+    const sortingMethod = getSortingMethod(
+      request.query.sort,
+      request.query.sortDirection
+    );
     const all = await worlds.find({}).sort(sortingMethod).toArray();
     return all;
   });

--- a/routes/page/index.js
+++ b/routes/page/index.js
@@ -12,12 +12,19 @@ const PAGE_SIZE = 27; // How many worlds per page to return
 
 export default async function (fastify, opts) {
   fastify.get("/:index", async function (request, reply) {
-    console.log(request.query.sort, getSortingMethod(request.query.sort)) 
     const index = request.params.index;
     const skip = Number.parseInt(index) * PAGE_SIZE;
-    const sortingMethod = getSortingMethod(request.query.sort)
+    const sortingMethod = getSortingMethod(
+      request.query.sort,
+      request.query.sortDirection
+    );
 
-    const matched_worlds = await worlds.find().sort(sortingMethod).skip(skip).limit(PAGE_SIZE).toArray();
+    const matched_worlds = await worlds
+      .find()
+      .sort(sortingMethod)
+      .skip(skip)
+      .limit(PAGE_SIZE)
+      .toArray();
     return matched_worlds;
   });
 }

--- a/routes/root.js
+++ b/routes/root.js
@@ -1,7 +1,9 @@
 "use strict";
 
+import { version } from '../package.json'
+
 export default async function (fastify, opts) {
   fastify.get("/", async function (request, reply) {
-    return { status: "ok" };
+    return { status: "ok", version: version };
   });
 }

--- a/routes/search/index.js
+++ b/routes/search/index.js
@@ -1,6 +1,7 @@
 "use strict";
 import "dotenv/config";
 import { MongoClient } from "mongodb";
+import { deRegexifyTheRegexSoTheUserDoesntDoMaliciousThings, getSortingMethod } from "../../util/getSortingMethod.js";
 
 const MONGO_URI = process.env.MONGO_URI;
 const DB = process.env.DB;
@@ -10,10 +11,17 @@ const worlds = mongoclient.db(DB).collection("worlds");
 
 export default async function (fastify, opts) {
   fastify.get("/:query", async function (request, reply) {
-    const query = request.params.query;
+    const query = deRegexifyTheRegexSoTheUserDoesntDoMaliciousThings(request.params.query);
+    const sortingMethod = getSortingMethod(
+      request.query.sort,
+      request.query.sortDirection
+    );
     if (!query) return [];
 
-    const matched_worlds = await worlds.find({ $text: { $search: query } }).toArray();
+    const matched_worlds = await worlds
+      .find({ name: { $regex: query, $options: "i" } })
+      .sort(sortingMethod)
+      .toArray();
     return matched_worlds;
   });
 }

--- a/routes/top/index.js
+++ b/routes/top/index.js
@@ -11,7 +11,11 @@ const worlds = mongoclient.db(DB).collection("worlds");
 export default async function (fastify, opts) {
   fastify.get("/:max", async function (request, reply) {
     const max = request.params.max;
-    const top_worlds = await worlds.find({}).sort({votes:-1}).limit(Number.parseInt(max)).toArray();
+    const top_worlds = await worlds
+      .find({})
+      .sort({ votes: -1 })
+      .limit(Number.parseInt(max))
+      .toArray();
     return top_worlds;
   });
 }

--- a/util/getSortingMethod.js
+++ b/util/getSortingMethod.js
@@ -1,13 +1,24 @@
 const SORTING_METHOD_LOOKUP = {
-    "default": { locked: -1, player_count: -1, votes: -1 }, // Online worlds first sorted by player count, then votes
-    "votes": { votes: -1 },
-    "visits": { visits: -1 },
-    "recently_scraped": { last_scraped: -1 },
+    ascending: {
+        "default": { locked: -1, player_count: -1, votes: -1 }, // Online worlds first sorted by player count, then votes
+        "votes": { votes: -1 },
+        "visits": { visits: -1 },
+        "recently_scraped": { last_scraped: -1 },
+        "recently_created": { creation_date_unix_time: -1 }
+    },
+    descending: {
+        "default": { locked: 1, player_count: 1, votes: 1 }, // Online worlds first sorted by player count, then votes
+        "votes": { votes: 1 },
+        "visits": { visits: 1 },
+        "recently_scraped": { last_scraped: 1 },
+        "recently_created": { creation_date_unix_time: 1 }
+    },
 }
 
-// ADD recently_added when creation_date_unix_time gets added.
+export const getSortingMethod = (sortMethod, direction) => {
+    const { ascending } = SORTING_METHOD_LOOKUP;
+    const directionLookup = SORTING_METHOD_LOOKUP[direction] || ascending;
+    return directionLookup[sortMethod] || directionLookup.default;
+};
 
-export const getSortingMethod = (sort) => {
-    if (!(sort in SORTING_METHOD_LOOKUP)) return SORTING_METHOD_LOOKUP["default"]
-    return SORTING_METHOD_LOOKUP[sort]
-}
+export const deRegexifyTheRegexSoTheUserDoesntDoMaliciousThings = input => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
- Made `/search` use `name: { $regex: query, $options: "i" }` (with query sanitized) to have better results when searching
- Added `recently_created` to the sorting options.
- Added `sortDirection` parameter to the `/all` and `/page` routes which accept `ascending | descending`. Defaults to `ascending`